### PR TITLE
Add branch header when provided as input to ContentType

### DIFF
--- a/contentstack_management/content_types/content_type.py
+++ b/contentstack_management/content_types/content_type.py
@@ -20,6 +20,8 @@ class ContentType(Parameter):
         self.client = client
         self.content_type_uid = content_type_uid
         self.branch = branch
+        if self.branch:
+            self.add_header('branch', branch)
         super().__init__(self.client)
 
     def find(self):


### PR DESCRIPTION
Noticed a issue when trying to create entries on a branch, ContentType correctly takes branch as input, but it's never appended to the list of headers.

I didn't check if other types supports branching feature and is having the samme issue as I'm mostly working with automation around entries.

Do let me know if that is a requirements for getting this PR in.