### PR TITLE
feat: add asset scanning unit tests for _asset_scan_status param and api_version header

### DIFF
--- a/tests/unit/assets/test_assets_unit.py
+++ b/tests/unit/assets/test_assets_unit.py
@@ -254,3 +254,80 @@ class AssetsUnitTests(unittest.TestCase):
         self.assertEqual(response.request.url, f"{self.client.endpoint}assets/folders/{folder_uid}")
         self.assertEqual(response.request.method, "DELETE")
         self.assertEqual(response.request.headers["Content-Type"], "application/json")
+
+    # Asset scanning tests — _asset_scan_status param and api_version header
+
+    def test_fetch_includes_scan_status_param(self):
+        asset = self.client.stack(api_key).assets(asset_uid)
+        asset.add_param("_asset_scan_status", True)
+        response = asset.fetch()
+        self.assertIn("_asset_scan_status=True", response.request.url)
+        self.assertEqual(response.request.method, "GET")
+
+    def test_find_includes_scan_status_param(self):
+        asset = self.client.stack(api_key).assets()
+        asset.add_param("_asset_scan_status", True)
+        response = asset.find()
+        self.assertIn("_asset_scan_status=True", response.request.url)
+        self.assertEqual(response.request.method, "GET")
+
+    def test_upload_includes_scan_status_param(self):
+        file_path = "tests/resources/mock_assets/chaat.jpeg"
+        asset = self.client.stack(api_key).assets()
+        asset.add_param("_asset_scan_status", True)
+        response = asset.upload(file_path)
+        self.assertIn("_asset_scan_status=True", response.request.url)
+        self.assertEqual(response.request.method, "POST")
+
+    def test_fetch_without_scan_status_param_field_absent(self):
+        response = self.client.stack(api_key).assets(asset_uid).fetch()
+        self.assertNotIn("_asset_scan_status", response.request.url)
+        self.assertEqual(response.request.method, "GET")
+
+    def test_find_without_scan_status_param_field_absent(self):
+        response = self.client.stack(api_key).assets().find()
+        self.assertNotIn("_asset_scan_status", response.request.url)
+        self.assertEqual(response.request.method, "GET")
+
+    def test_upload_without_scan_status_param_field_absent(self):
+        file_path = "tests/resources/mock_assets/chaat.jpeg"
+        response = self.client.stack(api_key).assets().upload(file_path)
+        self.assertNotIn("_asset_scan_status", response.request.url)
+        self.assertEqual(response.request.method, "POST")
+
+    def test_scan_status_param_coexists_with_other_params(self):
+        asset = self.client.stack(api_key).assets(asset_uid)
+        asset.add_param("locale", "en-us")
+        asset.add_param("_asset_scan_status", True)
+        response = asset.fetch()
+        self.assertIn("locale=en-us", response.request.url)
+        self.assertIn("_asset_scan_status=True", response.request.url)
+        self.assertEqual(response.request.method, "GET")
+
+    def test_publish_includes_api_version_header(self):
+        data = {
+            "asset": {
+                "locales": ["en-us"],
+                "environments": ["development"]
+            },
+            "version": 1,
+            "scheduled_at": "2019-02-08T18:30:00.000Z"
+        }
+        asset = self.client.stack(api_key).assets(asset_uid)
+        asset.add_header("api_version", "3.2")
+        response = asset.publish(data)
+        self.assertEqual(response.request.headers.get("api_version"), "3.2")
+        self.assertEqual(response.request.method, "POST")
+
+    def test_api_version_header_scoped_to_publish(self):
+        data = {
+            "asset": {
+                "locales": ["en-us"],
+                "environments": ["development"]
+            },
+            "version": 1,
+            "scheduled_at": "2019-02-08T18:30:00.000Z"
+        }
+        response = self.client.stack(api_key).assets(asset_uid).publish(data)
+        self.assertIsNone(response.request.headers.get("api_version"))
+        self.assertEqual(response.request.method, "POST")

--- a/tests/unit/assets/test_assets_unit.py
+++ b/tests/unit/assets/test_assets_unit.py
@@ -259,49 +259,49 @@ class AssetsUnitTests(unittest.TestCase):
 
     def test_fetch_includes_scan_status_param(self):
         asset = self.client.stack(api_key).assets(asset_uid)
-        asset.add_param("_asset_scan_status", True)
+        asset.add_param("include_asset_scan_status", True)
         response = asset.fetch()
-        self.assertIn("_asset_scan_status=True", response.request.url)
+        self.assertIn("include_asset_scan_status=True", response.request.url)
         self.assertEqual(response.request.method, "GET")
 
     def test_find_includes_scan_status_param(self):
         asset = self.client.stack(api_key).assets()
-        asset.add_param("_asset_scan_status", True)
+        asset.add_param("include_asset_scan_status", True)
         response = asset.find()
-        self.assertIn("_asset_scan_status=True", response.request.url)
+        self.assertIn("include_asset_scan_status=True", response.request.url)
         self.assertEqual(response.request.method, "GET")
 
     def test_upload_includes_scan_status_param(self):
         file_path = "tests/resources/mock_assets/chaat.jpeg"
         asset = self.client.stack(api_key).assets()
-        asset.add_param("_asset_scan_status", True)
+        asset.add_param("include_asset_scan_status", True)
         response = asset.upload(file_path)
-        self.assertIn("_asset_scan_status=True", response.request.url)
+        self.assertIn("include_asset_scan_status=True", response.request.url)
         self.assertEqual(response.request.method, "POST")
 
     def test_fetch_without_scan_status_param_field_absent(self):
         response = self.client.stack(api_key).assets(asset_uid).fetch()
-        self.assertNotIn("_asset_scan_status", response.request.url)
+        self.assertNotIn("include_asset_scan_status", response.request.url)
         self.assertEqual(response.request.method, "GET")
 
     def test_find_without_scan_status_param_field_absent(self):
         response = self.client.stack(api_key).assets().find()
-        self.assertNotIn("_asset_scan_status", response.request.url)
+        self.assertNotIn("include_asset_scan_status", response.request.url)
         self.assertEqual(response.request.method, "GET")
 
     def test_upload_without_scan_status_param_field_absent(self):
         file_path = "tests/resources/mock_assets/chaat.jpeg"
         response = self.client.stack(api_key).assets().upload(file_path)
-        self.assertNotIn("_asset_scan_status", response.request.url)
+        self.assertNotIn("include_asset_scan_status", response.request.url)
         self.assertEqual(response.request.method, "POST")
 
     def test_scan_status_param_coexists_with_other_params(self):
         asset = self.client.stack(api_key).assets(asset_uid)
         asset.add_param("locale", "en-us")
-        asset.add_param("_asset_scan_status", True)
+        asset.add_param("include_asset_scan_status", True)
         response = asset.fetch()
         self.assertIn("locale=en-us", response.request.url)
-        self.assertIn("_asset_scan_status=True", response.request.url)
+        self.assertIn("include_asset_scan_status=True", response.request.url)
         self.assertEqual(response.request.method, "GET")
 
     def test_publish_includes_api_version_header(self):


### PR DESCRIPTION
## Summary

- Add 9 unit tests to `AssetsUnitTests` covering the asset scanning feature
- Tests validate `include_asset_scan_status` query param behavior on `find()`, `fetch()`, and `upload()`
- Tests validate `api_version` header behavior on `publish()`
- No changes to core SDK files — uses existing `add_param()` / `add_header()` from `Parameter` base class

## Tests Added

| Test | Validates |
|------|-----------|
| `test_fetch_includes_scan_status_param` | `include_asset_scan_status=True` appears in URL when param is set |
| `test_find_includes_scan_status_param` | Same for `find()` |
| `test_upload_includes_scan_status_param` | Same for `upload()` |
| `test_fetch_without_scan_status_param_field_absent` | Param absent from URL when not set |
| `test_find_without_scan_status_param_field_absent` | Same for `find()` |
| `test_upload_without_scan_status_param_field_absent` | Same for `upload()` |
| `test_scan_status_param_coexists_with_other_params` | `locale` and `_asset_scan_status` both appear in URL |
| `test_publish_includes_api_version_header` | `api_version: 3.2` header sent when explicitly added |
| `test_api_version_header_scoped_to_publish` | `api_version` header absent when not added |

## Test Run
All 36 unit tests passed (`PYTHONPATH=. pytest tests/unit/assets/test_assets_unit.py -v`)