### PR TITLE
fix: remove hardcoded passwords in unit tests to resolve Snyk  issues 08-07-2026

### DIFF
--- a/tests/unit/user_session/test_user_session_totp.py
+++ b/tests/unit/user_session/test_user_session_totp.py
@@ -18,7 +18,7 @@ class UserSessionTOTPTests(unittest.TestCase):
         self.mock_client = MagicMock()
         self.user_session = UserSession(self.mock_client)
         self.test_email = "test@example.com"
-        self.test_password = "test_password"
+        self.test_password = os.getenv("TEST_PASSWORD", "test_password_placeholder")
         self.test_tfa_token = "123456"
 
     def test_login_with_tfa_token_uses_correct_field_name(self):

--- a/tests/unit/users/test_users.py
+++ b/tests/unit/users/test_users.py
@@ -44,8 +44,8 @@ class UserUnitTests(unittest.TestCase):
             "user": {
                 "first_name": "your_first_name",
                 "last_name": "your_last_name",
-                "password": "your_password",
-                "password_confirmation": "confirm_your_password"
+                "password": password,
+                "password_confirmation": password
             }
         }
         response = self.client.user().activate(activation_token, act_data)
@@ -70,8 +70,8 @@ class UserUnitTests(unittest.TestCase):
         act_data = {
             "user": {
                 "reset_password_token": "****",
-                "password": "Simple@123",
-                "password_confirmation": "Simple@123"
+                "password": password,
+                "password_confirmation": password
             }
         }
         response = self.client.user().reset_password(act_data)


### PR DESCRIPTION
## Fixes
- tests/unit/user_session/test_user_session_totp.py: source test_password via os.getenv("TEST_PASSWORD", ...) instead of a bare literal
- tests/unit/users/test_users.py: reuse the existing `password` variable (already loaded from env via tests/cred.py) in test_active_user and test_reset_password instead of hardcoded literals